### PR TITLE
add more debug info to the output

### DIFF
--- a/scan.sh
+++ b/scan.sh
@@ -4,10 +4,17 @@ FAILED=0
 
 echo "Testing bluetooth. Make sure you have a bluetooth device enabled and visible."
 
-echo "Scan for devices..."
-if [ `hcitool scan | wc -l` -le 1 ]; then
+hcitool dev
+
+echo "Scan for nearby blueooth devices..."
+mapfile -t scanresult < <(hcitool scan)
+if [ ${#scanresult[@]} -le 1 ]; then
     FAILED=1
 else
+    echo "Found these devices:"
+    for (( i=1; i<${#scanresult[@]}; i++ )); do
+        echo ${scanresult[i]};
+    done
     FAILED=0
 fi
 


### PR DESCRIPTION
Sometimes it's helpful to know what bluetooth devices were found, add that to the test output for debug purposes; as well as including the available bluetooth device of the DUT.