### PR TITLE
scan.sh: Use bluetootctl for Intel Edison

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -5,5 +5,6 @@ RUN apt-get update && apt-get install bluez
 WORKDIR usr/src/app
 
 COPY scan.sh ./
+COPY btctl ./btctl
 
 CMD ["bash", "scan.sh"]

--- a/btctl/btctl_commands.sh
+++ b/btctl/btctl_commands.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# This script contains commands
+# for bluetoothctl tool
+
+echo -e 'power on\n'
+sleep 2
+echo -e 'agent on\n'
+echo -e 'default-agent\n'
+echo -e 'scan on\n'
+sleep 10
+echo -e 'scan off\n'
+sleep 2
+echo -e 'devices\n'
+sleep 1;
+echo -e 'quit\n'

--- a/btctl/test_btctl.sh
+++ b/btctl/test_btctl.sh
@@ -1,0 +1,20 @@
+#/bin/sh
+
+DEVS=0
+FAILED=0
+
+export DBUS_SYSTEM_BUS_ADDRESS=unix:path=/host/run/dbus/system_bus_socket
+
+/bin/bash ./$(dirname $0)/btctl_commands.sh | bluetoothctl | grep "Device"  > ./devices
+DEVS=`wc -l ./devices | awk '{print $1}'`;
+if [ $DEVS -le 1 ]; then
+    FAILED=1;
+else
+    echo "Found devices:";
+    cat ./devices;
+    FAILED=0;
+fi;
+
+rm ./devices;
+
+exit $FAILED;

--- a/scan.sh
+++ b/scan.sh
@@ -4,6 +4,21 @@ FAILED=0
 
 echo "Testing bluetooth. Make sure you have a bluetooth device enabled and visible."
 
+# For Intel Edison use bluetoothctl
+if [ "x$BALENA_DEVICE_TYPE" == "xintel-edison" ]; then
+    /bin/bash ./btctl/test_btctl.sh;
+    if [ $? -eq 0 ]; then
+        echo "TEST PASSED"
+    else
+        echo "TEST FAILED"
+    fi
+
+    # Don't exit the process
+    while true; do
+        sleep 1
+    done
+fi;
+
 hcitool dev
 
 echo "Scan for nearby blueooth devices..."


### PR DESCRIPTION
Added scripts to use bluetoothctl to test
bluetooth features. This is used for Intel
Edison for now because it's the only system
on which there's no more support for hcitool

Change-type: Patch
Signed-off-by: Alexandru Costache <alexandru@balena.io>